### PR TITLE
Add roadmap bindings to hpp-python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_branch: devel
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.10
+  rev: v0.11.0
   hooks:
   - id: ruff
     args:
@@ -18,7 +18,7 @@ repos:
   hooks:
   - id: toml-sort-fix
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.7
+  rev: v20.1.0
   hooks:
   - id: clang-format
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_branch: devel
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.0
+  rev: v0.11.6
   hooks:
   - id: ruff
     args:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ add_project_dependency(hpp-pinocchio REQUIRED)
 add_project_dependency(hpp-constraints REQUIRED)
 add_project_dependency(hpp-core REQUIRED)
 add_project_dependency(hpp-corbaserver REQUIRED)
+add_project_dependency(hpp-manipulation REQUIRED)
+add_project_dependency(hpp-manipulation-urdf REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 install(

--- a/include/pyhpp/core/fwd.hh
+++ b/include/pyhpp/core/fwd.hh
@@ -34,6 +34,9 @@ void exposeReports();
 
 void exposeSteeringMethod();
 
+void exposeNode();
+void exposeRoadmap();
+
 void exposePath();
 void exposePathOptimizer();
 void exposePathProjector();

--- a/include/pyhpp/core/problemTarget/fwd.hh
+++ b/include/pyhpp/core/problemTarget/fwd.hh
@@ -17,37 +17,17 @@
 // hpp-python  If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef PYHPP_CORE_FWD_HH
-#define PYHPP_CORE_FWD_HH
+#ifndef PYHPP_CORE_PROBLEM_TARGET_FWD_HH
+#define PYHPP_CORE_ROBLEM_TARGET_FWD_HH
 
 #include <pyhpp/util.hh>
 
 namespace pyhpp {
 namespace core {
-void exposeConfigValidation();
-void exposeConfigurationShooter();
-void exposeConstraint();
-
-void exposeEquation();
-
-void exposeReports();
-
-void exposeSteeringMethod();
-
-void exposeNode();
-void exposeDistance();
-void exposeConnectedComponent();
-void exposeRoadmap();
-void exposeProblemTarget();
-
-void exposePath();
-void exposePathOptimizer();
-void exposePathProjector();
-void exposePathValidation();
-void exposeParameter();
-void exposeProblem();
-void exposeProblemSolver();
+namespace problemTarget {
+  void exposeGoalConfigurations();
+}  // namespace problemTarget
 }  // namespace core
 }  // namespace pyhpp
 
-#endif  // PYHPP_CORE_FWD_HH
+#endif  // PYHPP_CORE_PROBLEM_TARGET_FWD_HH

--- a/include/pyhpp/manipulation/fwd.hh
+++ b/include/pyhpp/manipulation/fwd.hh
@@ -1,6 +1,7 @@
 //
-// Copyright (c) 2018 - 2023, CNRS
-// Authors: Joseph Mirabel, Florent Lamiraux
+// Copyright (c) 2025 CNRS
+// Authors: Florent Lamiraux
+//
 //
 // This file is part of hpp-python
 // hpp-python is free software: you can redistribute it
@@ -16,22 +17,16 @@
 // hpp-python  If not, see
 // <http://www.gnu.org/licenses/>.
 
-#include <boost/python.hpp>
-#include <hpp/pinocchio/urdf/util.hh>
-#include <pyhpp/pinocchio/urdf/fwd.hh>
+#ifndef PYHPP_MANIPULATION_FWD_HH
+#define PYHPP_MANIPULATION_FWD_HH
 
-using namespace boost::python;
+#include <pyhpp/util.hh>
 
 namespace pyhpp {
-namespace pinocchio {
-namespace urdf {
-using hpp::pinocchio::DevicePtr_t;
-using namespace hpp::pinocchio::urdf;
-
-void exposeUtil() {
-  def("loadModel", &loadModel);
-  def("loadModelFromString", &loadModelFromString);
-}
-}  // namespace urdf
-}  // namespace pinocchio
+namespace manipulation {
+void exposeDevice();
+void exposeHandle();
+}  // namespace manipulation
 }  // namespace pyhpp
+
+#endif  // PYHPP_MANIPULATION_FWD_HH

--- a/include/pyhpp/manipulation/urdf/fwd.hh
+++ b/include/pyhpp/manipulation/urdf/fwd.hh
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2018 - 2023, CNRS
-// Authors: Joseph Mirabel, Florent Lamiraux
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
 //
 // This file is part of hpp-python
 // hpp-python is free software: you can redistribute it
@@ -16,22 +16,17 @@
 // hpp-python  If not, see
 // <http://www.gnu.org/licenses/>.
 
-#include <boost/python.hpp>
-#include <hpp/pinocchio/urdf/util.hh>
-#include <pyhpp/pinocchio/urdf/fwd.hh>
+#ifndef PYHPP_MANIPULATION_UTIL_FWD_HH
+#define PYHPP_MANIPULATION_UTIL_FWD_HH
 
-using namespace boost::python;
+#include <pyhpp/util.hh>
 
 namespace pyhpp {
-namespace pinocchio {
+namespace manipulation {
 namespace urdf {
-using hpp::pinocchio::DevicePtr_t;
-using namespace hpp::pinocchio::urdf;
-
-void exposeUtil() {
-  def("loadModel", &loadModel);
-  def("loadModelFromString", &loadModelFromString);
-}
+void exposeUtil();
 }  // namespace urdf
-}  // namespace pinocchio
+}  // namespace manipulation
 }  // namespace pyhpp
+
+#endif  // PYHPP_MANIPULATION_UTIL_FWD_HH

--- a/include/pyhpp/pinocchio/fwd.hh
+++ b/include/pyhpp/pinocchio/fwd.hh
@@ -26,6 +26,7 @@ namespace pyhpp {
 namespace pinocchio {
 void exposeModel();
 void exposeDevice();
+void exposeGripper();
 void exposeLiegroup();
 }  // namespace pinocchio
 }  // namespace pyhpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,3 +125,21 @@ add_python_library(
 add_python_library(
   pyhpp/corbaserver FILES pyhpp/corbaserver/bindings.cc
   pyhpp/corbaserver/server.cc LINK_LIBRARIES hpp-corbaserver::hpp-corbaserver)
+
+add_python_library(
+  pyhpp/manipulation
+  FILES
+  pyhpp/manipulation/bindings.cc
+  pyhpp/manipulation/device.cc
+  LINK_LIBRARIES
+  hpp-manipulation::hpp-manipulation
+  )
+
+add_python_library(
+  pyhpp/manipulation/urdf
+  FILES
+  pyhpp/manipulation/urdf/util.cc
+  pyhpp/manipulation/urdf/bindings.cc
+  LINK_LIBRARIES
+  hpp-manipulation-urdf::hpp-manipulation-urdf
+  )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,7 @@ add_python_library(
   FILES
   pyhpp/manipulation/bindings.cc
   pyhpp/manipulation/device.cc
+  pyhpp/manipulation/graph.cc
   LINK_LIBRARIES
   hpp-manipulation::hpp-manipulation
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,10 +99,21 @@ add_python_library(
   pyhpp/core/path-optimizer.cc
   pyhpp/core/path-projector.cc
   pyhpp/core/path-validation.cc
+  pyhpp/core/connected-component.cc
+  pyhpp/core/distance.cc
+  pyhpp/core/problem-target.cc
   pyhpp/core/parameter.cc
   pyhpp/core/problem.cc
   pyhpp/core/problem-solver.cc
   pyhpp/core/bindings.cc
+  LINK_LIBRARIES
+  hpp-core::hpp-core)
+
+add_python_library(
+  pyhpp/core/problem_target
+  FILES
+  pyhpp/core/problem_target/goal-configurations.cc
+  pyhpp/core/problem_target/bindings.cc
   LINK_LIBRARIES
   hpp-core::hpp-core)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,8 @@ add_python_library(
 add_python_library(
   pyhpp/core
   FILES
+  pyhpp/core/node.cc
+  pyhpp/core/roadmap.cc
   pyhpp/core/config-validation.cc
   pyhpp/core/configuration-shooter.cc
   pyhpp/core/constraint.cc

--- a/src/pyhpp/constraints/iterative-solver.cc
+++ b/src/pyhpp/constraints/iterative-solver.cc
@@ -34,11 +34,6 @@ using namespace hpp::constraints;
 using namespace hpp::constraints::solver;
 
 void exposeHierarchicalIterativeSolver() {
-  enum_<ComparisonType>("ComparisonType")
-      .value("Equality", Equality)
-      .value("EqualToZero", EqualToZero)
-      .value("Superior", Superior)
-      .value("Inferior", Inferior);
   class_<ComparisonTypes_t>("ComparisonTypes")
       .def(vector_indexing_suite<ComparisonTypes_t>());
 

--- a/src/pyhpp/core/bindings.cc
+++ b/src/pyhpp/core/bindings.cc
@@ -39,6 +39,8 @@ BOOST_PYTHON_MODULE(bindings) {
   pyhpp::core::exposeConstraint();
   pyhpp::core::exposeReports();
   pyhpp::core::exposeSteeringMethod();
+  pyhpp::core::exposeNode();
+  pyhpp::core::exposeRoadmap();
 
   // Expose main abstract classes
   pyhpp::core::exposePath();

--- a/src/pyhpp/core/bindings.cc
+++ b/src/pyhpp/core/bindings.cc
@@ -40,7 +40,10 @@ BOOST_PYTHON_MODULE(bindings) {
   pyhpp::core::exposeReports();
   pyhpp::core::exposeSteeringMethod();
   pyhpp::core::exposeNode();
+  pyhpp::core::exposeDistance();
+  pyhpp::core::exposeConnectedComponent();
   pyhpp::core::exposeRoadmap();
+  pyhpp::core::exposeProblemTarget();
 
   // Expose main abstract classes
   pyhpp::core::exposePath();
@@ -50,4 +53,7 @@ BOOST_PYTHON_MODULE(bindings) {
 
   boost::python::import("pyhpp.core.path");
   boost::python::import("pyhpp.core.path_optimization");
+  
+  boost::python::import("pyhpp.core.problem_target");
+
 }

--- a/src/pyhpp/core/connected-component.cc
+++ b/src/pyhpp/core/connected-component.cc
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2018 CNRS
-// Authors: Joseph Mirabel
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
 //
 //
 // This file is part of hpp-python
@@ -17,37 +17,20 @@
 // hpp-python  If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef PYHPP_CORE_FWD_HH
-#define PYHPP_CORE_FWD_HH
+#include <boost/python.hpp>
+#include <hpp/core/connected-component.hh>
+#include <hpp/core/problem.hh>
+#include <pyhpp/core/fwd.hh>
 
-#include <pyhpp/util.hh>
+using namespace boost::python;
 
 namespace pyhpp {
 namespace core {
-void exposeConfigValidation();
-void exposeConfigurationShooter();
-void exposeConstraint();
+using namespace hpp::core;
 
-void exposeEquation();
-
-void exposeReports();
-
-void exposeSteeringMethod();
-
-void exposeNode();
-void exposeDistance();
-void exposeConnectedComponent();
-void exposeRoadmap();
-void exposeProblemTarget();
-
-void exposePath();
-void exposePathOptimizer();
-void exposePathProjector();
-void exposePathValidation();
-void exposeParameter();
-void exposeProblem();
-void exposeProblemSolver();
+void exposeConnectedComponent() {
+  class_<ConnectedComponent, ConnectedComponentPtr_t, boost::noncopyable>("ConnectedComponent",
+                                                                no_init);
+}
 }  // namespace core
 }  // namespace pyhpp
-
-#endif  // PYHPP_CORE_FWD_HH

--- a/src/pyhpp/core/distance.cc
+++ b/src/pyhpp/core/distance.cc
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
+//
+// This file is part of hpp-core.
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core. If not, see <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/core/distance.hh>
+#include <hpp/core/weighed-distance.hh>
+#include <pyhpp/core/fwd.hh>
+#include <pyhpp/util.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace core {
+
+using namespace hpp::core;
+
+struct DistanceWrapper {
+  static DistancePtr_t AsDistancePtr_t(WeighedDistance& dist) {
+    return dist.clone();
+  }
+};
+
+void exposeDistance() {
+
+  class_<Distance, DistancePtr_t, boost::noncopyable>("Distance", no_init);
+  class_<WeighedDistance, WeighedDistancePtr_t, boost::noncopyable>("WeighedDistance", no_init)
+    .def("create", &WeighedDistance::create).staticmethod("create")
+    .def("asDistancePtr_t", &DistanceWrapper::AsDistancePtr_t);
+;
+}
+}  // namespace core
+}  // namespace pyhpp

--- a/src/pyhpp/core/node.cc
+++ b/src/pyhpp/core/node.cc
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
+//
+// This file is part of hpp-core.
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core. If not, see <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/core/node.hh>
+#include <hpp/core/edge.hh>
+#include <hpp/core/connected-component.hh>
+#include <pyhpp/core/fwd.hh>
+#include <pyhpp/util.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace core {
+
+using namespace hpp::core;
+
+void exposeNode() {
+
+  class_<Node, boost::shared_ptr<Node>, boost::noncopyable>("Node", no_init)
+    .def(init<ConfigurationIn_t>())
+    .def(init<ConfigurationIn_t, ConnectedComponentPtr_t>())
+    .PYHPP_DEFINE_METHOD(Node, addOutEdge)
+    .PYHPP_DEFINE_METHOD(Node, addInEdge)
+    .def("connectedComponent",
+      static_cast<ConnectedComponentPtr_t (Node::*)() const>(&Node::connectedComponent))
+    .def("connectedComponent",
+      static_cast<void (Node::*)(const ConnectedComponentPtr_t&)>(&Node::connectedComponent))
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Node, outEdges)
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Node, inEdges)
+    .PYHPP_DEFINE_METHOD(Node, isOutNeighbor)
+    .PYHPP_DEFINE_METHOD(Node, isInNeighbor)
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Node, configuration)
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Node, print)
+;
+}
+}  // namespace core
+}  // namespace pyhpp

--- a/src/pyhpp/core/problem-target.cc
+++ b/src/pyhpp/core/problem-target.cc
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
+//
+// This file is part of hpp-core.
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core. If not, see <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/core/problem-target.hh>
+#include <pyhpp/core/fwd.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace core {
+
+using namespace hpp::core;
+
+void exposeProblemTarget() {
+
+  class_<ProblemTarget, ProblemTargetPtr_t, boost::noncopyable>("ProblemTarget", no_init)
+
+;
+}
+}  // namespace core
+}  // namespace pyhpp

--- a/src/pyhpp/core/problem.cc
+++ b/src/pyhpp/core/problem.cc
@@ -21,6 +21,7 @@
 #include <hpp/core/configuration-shooter.hh>
 #include <hpp/core/path-projector.hh>
 #include <hpp/core/path-validation.hh>
+#include <hpp/core/problem-target.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/steering-method.hh>
 #include <pyhpp/core/fwd.hh>
@@ -38,6 +39,7 @@ void exposeProblem() {
   class_<Problem, ProblemPtr_t, boost::noncopyable>("Problem", no_init)
       // .PYHPP_DEFINE_GETTER_SETTER_INTERNAL_REF (Problem, robot, const
       // DevicePtr_t&)
+      .def("create", &Problem::create).staticmethod("create")
       .def(
           "robot",
           static_cast<const DevicePtr_t& (Problem::*)() const>(&Problem::robot),
@@ -60,7 +62,12 @@ void exposeProblem() {
                &Problem::pathValidation))
       .def("pathProjector",
            static_cast<PathProjectorPtr_t (Problem::*)() const>(
-               &Problem::pathProjector));
+               &Problem::pathProjector))
+      .def("target",
+            static_cast<const ProblemTargetPtr_t& (Problem::*)() const>(&Problem::target),
+             return_value_policy<return_by_value>())
+
+    ;
 }
 }  // namespace core
 }  // namespace pyhpp

--- a/src/pyhpp/core/problem_target/bindings.cc
+++ b/src/pyhpp/core/problem_target/bindings.cc
@@ -1,7 +1,6 @@
 //
-// Copyright (c) 2018 CNRS
-// Authors: Joseph Mirabel
-//
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
 //
 // This file is part of hpp-python
 // hpp-python is free software: you can redistribute it
@@ -17,37 +16,12 @@
 // hpp-python  If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef PYHPP_CORE_FWD_HH
-#define PYHPP_CORE_FWD_HH
-
+#include <boost/python.hpp>
+#include <pyhpp/core/problemTarget/fwd.hh>
 #include <pyhpp/util.hh>
 
-namespace pyhpp {
-namespace core {
-void exposeConfigValidation();
-void exposeConfigurationShooter();
-void exposeConstraint();
+BOOST_PYTHON_MODULE(bindings) {
+  INIT_PYHPP_MODULE;
 
-void exposeEquation();
-
-void exposeReports();
-
-void exposeSteeringMethod();
-
-void exposeNode();
-void exposeDistance();
-void exposeConnectedComponent();
-void exposeRoadmap();
-void exposeProblemTarget();
-
-void exposePath();
-void exposePathOptimizer();
-void exposePathProjector();
-void exposePathValidation();
-void exposeParameter();
-void exposeProblem();
-void exposeProblemSolver();
-}  // namespace core
-}  // namespace pyhpp
-
-#endif  // PYHPP_CORE_FWD_HH
+  pyhpp::core::problemTarget::exposeGoalConfigurations();
+}

--- a/src/pyhpp/core/problem_target/goal-configurations.cc
+++ b/src/pyhpp/core/problem_target/goal-configurations.cc
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
+//
+// This file is part of hpp-core.
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core. If not, see <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/core/problem-target/goal-configurations.hh>
+#include <hpp/core/path-vector.hh>
+#include <pyhpp/core/fwd.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace core {
+namespace problemTarget {
+using namespace hpp::core::problemTarget;
+
+void exposeGoalConfigurations() {
+
+  class_<GoalConfigurations, GoalConfigurationsPtr_t, bases<hpp::core::ProblemTarget>, boost::noncopyable>("GoalConfigurations", no_init)
+    .def("create", &GoalConfigurations::create)
+    .PYHPP_DEFINE_METHOD(GoalConfigurations, computePath)
+    .PYHPP_DEFINE_METHOD(GoalConfigurations, reached)
+
+;
+}
+}  // namespace problemTarget;
+}  // namespace core
+}  // namespace pyhpp

--- a/src/pyhpp/core/roadmap.cc
+++ b/src/pyhpp/core/roadmap.cc
@@ -42,22 +42,32 @@ struct RWrapper {
     roadmap.addNode(config);
   }
 
-  static void addEdge(Roadmap& roadmap, const NodePtr_t &n1, const NodePtr_t &n2, const PathPtr_t &path) {
-    roadmap.addEdge(n1, n2, path);
+  static void addEdge(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t &path) {
+    NodePtr_t nodeFrom = roadmap.addNode(from);
+    NodePtr_t nodeTo = roadmap.addNode(to);
+    roadmap.addEdge(nodeFrom, nodeTo, path);
     return;
   }
 
-  static const Configuration_t& nearestNode1(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance, bool reverse) {
-    return roadmap.nearestNode(configuration, minDistance, reverse)->configuration();
+  static boost::python::tuple nearestNode1(Roadmap& roadmap, ConfigurationIn_t configuration, bool reverse) {
+    double minDistance;
+    NodePtr_t node = roadmap.nearestNode(configuration, minDistance, reverse);
+    return boost::python::make_tuple(node->configuration(), minDistance);
   }
-  static NodePtr_t nearestNode2(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance) {
-    return roadmap.nearestNode(configuration, minDistance);
+  static boost::python::tuple nearestNode2(Roadmap& roadmap, ConfigurationIn_t configuration) {
+    double minDistance;
+    NodePtr_t node = roadmap.nearestNode(configuration, minDistance);
+    return boost::python::make_tuple(node->configuration(), minDistance);
   }
-  static NodePtr_t nearestNode3(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent, value_type &minDistance, bool reverse) {
-    return roadmap.nearestNode(configuration, connectedComponent, minDistance, reverse);
+  static boost::python::tuple nearestNode3(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent, bool reverse) {
+    double minDistance;
+    NodePtr_t node = roadmap.nearestNode(configuration, connectedComponent, minDistance, reverse);
+    return boost::python::make_tuple(node->configuration(), minDistance);
   }
-  static NodePtr_t nearestNode4(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent, value_type &minDistance) {
-    return roadmap.nearestNode(configuration, connectedComponent, minDistance);
+  static boost::python::tuple nearestNode4(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent) {
+    double minDistance;
+    NodePtr_t node = roadmap.nearestNode(configuration, connectedComponent, minDistance);
+    return boost::python::make_tuple(node->configuration(), minDistance);
   }
 
   static Nodes_t nearestNodes1(Roadmap& roadmap, ConfigurationIn_t configuration, size_type k) {
@@ -75,6 +85,17 @@ struct RWrapper {
     return roadmap.initNode();
   }
 
+  static int numberConnectedComponents(Roadmap& roadmap) {
+    return roadmap.connectedComponents().size();
+  }
+
+  static ConnectedComponentPtr_t getConnectedComponent(Roadmap& roadmap, int connectedComponentId) {
+     ConnectedComponents_t::const_iterator itcc =
+          roadmap.connectedComponents().begin();
+      std::advance(itcc, connectedComponentId);
+    return *itcc;
+  }
+
   // static void cost1(Roadmap& roadmap, const path::CostPtr_t &cost) {
   //   roadmap.cost(cost);
   //   return;
@@ -82,19 +103,19 @@ struct RWrapper {
   // static path::CostPtr_t cost2(Roadmap& roadmap) {
   //   return roadmap.cost();
   // }
-
 };
 
 void exposeRoadmap() {
 
   class_<Roadmap, RoadmapPtr_t, boost::noncopyable>("Roadmap", no_init)
     .def("create", &Roadmap::create).staticmethod("create")
+    .def("__str__", &to_str<Roadmap>)
     .PYHPP_DEFINE_METHOD(Roadmap, clear)
     .PYHPP_DEFINE_METHOD1(RWrapper, addNode, return_value_policy<reference_existing_object>())
-    .def("nearestNode", &RWrapper::nearestNode1, return_value_policy<reference_existing_object>())
-    .def("nearestNode", &RWrapper::nearestNode2, return_value_policy<reference_existing_object>())
-    .def("nearestNode", &RWrapper::nearestNode3, return_value_policy<reference_existing_object>())
-    .def("nearestNode", &RWrapper::nearestNode4, return_value_policy<reference_existing_object>())
+    .def("nearestNode", &RWrapper::nearestNode1)
+    .def("nearestNode", &RWrapper::nearestNode2)
+    .def("nearestNode", &RWrapper::nearestNode3)
+    .def("nearestNode", &RWrapper::nearestNode4)
     .def("nearestNodes", &RWrapper::nearestNodes1)
     .def("nearestNodes", &RWrapper::nearestNodes2)
     .PYHPP_DEFINE_METHOD(Roadmap, nodesWithinBall)
@@ -104,7 +125,7 @@ void exposeRoadmap() {
     .PYHPP_DEFINE_METHOD(Roadmap, addEdges)
     .def("merge", static_cast<void (Roadmap::*)(const RoadmapPtr_t&)>(&Roadmap::merge))
     .PYHPP_DEFINE_METHOD(Roadmap, insertPathVector)
-    .PYHPP_DEFINE_METHOD1(Roadmap, addGoalNode, return_value_policy<manage_new_object>())
+    .PYHPP_DEFINE_METHOD1(Roadmap, addGoalNode, return_value_policy<reference_existing_object>())
     .PYHPP_DEFINE_METHOD(Roadmap, resetGoalNodes)
     .PYHPP_DEFINE_METHOD(Roadmap, pathExists)
     .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, nodes)
@@ -113,6 +134,8 @@ void exposeRoadmap() {
     .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, goalNodes)
     .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, connectedComponents)
     .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, distance)
+    .def("numberConnectedComponents", &RWrapper::numberConnectedComponents)
+    .def("getConnectedComponent", &RWrapper::getConnectedComponent)
     // .def("cost", &RWrapper::cost1)
     // .def("cost", &RWrapper::cost2, return_value_policy<reference_existing_object>())
 

--- a/src/pyhpp/core/roadmap.cc
+++ b/src/pyhpp/core/roadmap.cc
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2018 - 2023, CNRS
+// Authors: Joseph Mirabel, Florent Lamiraux
+//
+// This file is part of hpp-core.
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core. If not, see <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/core/roadmap.hh>
+#include <pyhpp/core/fwd.hh>
+#include <pyhpp/util.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace core {
+
+using namespace hpp::core;
+
+struct RWrapper {
+  static NodePtr_t addNodeAndEdges(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t path) {
+    NodePtr_t nodeFrom = roadmap.addNode(from);
+    return roadmap.addNodeAndEdges(nodeFrom, to, path);
+  }
+
+  static NodePtr_t addNodeAndEdge(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t path) {
+    NodePtr_t nodeFrom = roadmap.addNode(from);
+    return roadmap.addNodeAndEdge(nodeFrom, to, path);
+  }
+
+  static NodePtr_t addNode(Roadmap& roadmap, const ConfigurationIn_t config) {
+    return roadmap.addNode(config);
+  }
+
+  static void addEdge(Roadmap& roadmap, const NodePtr_t &n1, const NodePtr_t &n2, const PathPtr_t &path) {
+    roadmap.addEdge(n1, n2, path);
+    return;
+  }
+
+  static NodePtr_t nearestNode1(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance, bool reverse) {
+    return roadmap.nearestNode(configuration, minDistance, reverse);
+  }
+  static NodePtr_t nearestNode2(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance) {
+    return roadmap.nearestNode(configuration, minDistance);
+  }
+  static NodePtr_t nearestNode3(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent, value_type &minDistance, bool reverse) {
+    return roadmap.nearestNode(configuration, connectedComponent, minDistance, reverse);
+  }
+  static NodePtr_t nearestNode4(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent, value_type &minDistance) {
+    return roadmap.nearestNode(configuration, connectedComponent, minDistance);
+  }
+
+  static Nodes_t nearestNodes1(Roadmap& roadmap, ConfigurationIn_t configuration, size_type k) {
+    return roadmap.nearestNodes(configuration, k);
+  }
+  static Nodes_t nearestNodes2(Roadmap& roadmap, ConfigurationIn_t configuration, const ConnectedComponentPtr_t &connectedComponent, size_type k) {
+    return roadmap.nearestNodes(configuration, connectedComponent, k);
+  }
+
+  static void initNode1(Roadmap& roadmap, ConfigurationIn_t configuration) {
+    roadmap.initNode(configuration);
+    return;
+  }
+  static NodePtr_t initNode2(Roadmap& roadmap) {
+    return roadmap.initNode();
+  }
+
+  // static void cost1(Roadmap& roadmap, const path::CostPtr_t &cost) {
+  //   roadmap.cost(cost);
+  //   return;
+  // }
+  // static path::CostPtr_t cost2(Roadmap& roadmap) {
+  //   return roadmap.cost();
+  // }
+
+};
+
+void exposeRoadmap() {
+
+  class_<Roadmap, RoadmapPtr_t, boost::noncopyable>("Roadmap", no_init)
+    .def("create", &Roadmap::create).staticmethod("create")
+    .PYHPP_DEFINE_METHOD(Roadmap, clear)
+    .PYHPP_DEFINE_METHOD1(RWrapper, addNode, return_value_policy<reference_existing_object>())
+    .def("nearestNode", &RWrapper::nearestNode1, return_value_policy<reference_existing_object>())
+    .def("nearestNode", &RWrapper::nearestNode2, return_value_policy<reference_existing_object>())
+    .def("nearestNode", &RWrapper::nearestNode3, return_value_policy<reference_existing_object>())
+    .def("nearestNode", &RWrapper::nearestNode4, return_value_policy<reference_existing_object>())
+    .def("nearestNodes", &RWrapper::nearestNodes1)
+    .def("nearestNodes", &RWrapper::nearestNodes2)
+    .PYHPP_DEFINE_METHOD(Roadmap, nodesWithinBall)
+    .PYHPP_DEFINE_METHOD1(RWrapper, addNodeAndEdges, return_value_policy<manage_new_object>())
+    .PYHPP_DEFINE_METHOD1(RWrapper, addNodeAndEdge, return_value_policy<manage_new_object>())
+    .PYHPP_DEFINE_METHOD(RWrapper, addEdge)
+    .PYHPP_DEFINE_METHOD(Roadmap, addEdges)
+    .def("merge", static_cast<void (Roadmap::*)(const RoadmapPtr_t&)>(&Roadmap::merge))
+    .PYHPP_DEFINE_METHOD(Roadmap, insertPathVector)
+    .PYHPP_DEFINE_METHOD1(Roadmap, addGoalNode, return_value_policy<manage_new_object>())
+    .PYHPP_DEFINE_METHOD(Roadmap, resetGoalNodes)
+    .PYHPP_DEFINE_METHOD(Roadmap, pathExists)
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, nodes)
+    .def("initNode", &RWrapper::initNode1)
+    .def("initNode", &RWrapper::initNode2, return_value_policy<manage_new_object>())
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, goalNodes)
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, connectedComponents)
+    .PYHPP_DEFINE_METHOD_INTERNAL_REF(Roadmap, distance)
+    // .def("cost", &RWrapper::cost1)
+    // .def("cost", &RWrapper::cost2, return_value_policy<reference_existing_object>())
+
+
+
+;
+}
+}  // namespace core
+}  // namespace pyhpp

--- a/src/pyhpp/core/roadmap.cc
+++ b/src/pyhpp/core/roadmap.cc
@@ -28,18 +28,18 @@ namespace core {
 using namespace hpp::core;
 
 struct RWrapper {
-  static NodePtr_t addNodeAndEdges(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t path) {
+  static void addNodeAndEdges(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t path) {
     NodePtr_t nodeFrom = roadmap.addNode(from);
-    return roadmap.addNodeAndEdges(nodeFrom, to, path);
+    roadmap.addNodeAndEdges(nodeFrom, to, path);
   }
 
-  static NodePtr_t addNodeAndEdge(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t path) {
+  static void addNodeAndEdge(Roadmap& roadmap, const ConfigurationIn_t from, ConfigurationIn_t to, const PathPtr_t path) {
     NodePtr_t nodeFrom = roadmap.addNode(from);
-    return roadmap.addNodeAndEdge(nodeFrom, to, path);
+    roadmap.addNodeAndEdge(nodeFrom, to, path);
   }
 
-  static NodePtr_t addNode(Roadmap& roadmap, const ConfigurationIn_t config) {
-    return roadmap.addNode(config);
+  static void addNode(Roadmap& roadmap, const ConfigurationIn_t config) {
+    roadmap.addNode(config);
   }
 
   static void addEdge(Roadmap& roadmap, const NodePtr_t &n1, const NodePtr_t &n2, const PathPtr_t &path) {
@@ -47,8 +47,8 @@ struct RWrapper {
     return;
   }
 
-  static NodePtr_t nearestNode1(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance, bool reverse) {
-    return roadmap.nearestNode(configuration, minDistance, reverse);
+  static const Configuration_t& nearestNode1(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance, bool reverse) {
+    return roadmap.nearestNode(configuration, minDistance, reverse)->configuration();
   }
   static NodePtr_t nearestNode2(Roadmap& roadmap, ConfigurationIn_t configuration, value_type &minDistance) {
     return roadmap.nearestNode(configuration, minDistance);

--- a/src/pyhpp/manipulation/bindings.cc
+++ b/src/pyhpp/manipulation/bindings.cc
@@ -24,6 +24,7 @@ BOOST_PYTHON_MODULE(bindings) {
   INIT_PYHPP_MODULE;
 
   boost::python::import("pyhpp.pinocchio");
+  boost::python::import("pyhpp.constraints");
   pyhpp::manipulation::exposeHandle();
   pyhpp::manipulation::exposeDevice();
 }

--- a/src/pyhpp/manipulation/bindings.cc
+++ b/src/pyhpp/manipulation/bindings.cc
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2018 - 2023, CNRS
-// Authors: Joseph Mirabel, Florent Lamiraux
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
 //
 // This file is part of hpp-python
 // hpp-python is free software: you can redistribute it
@@ -17,21 +17,13 @@
 // <http://www.gnu.org/licenses/>.
 
 #include <boost/python.hpp>
-#include <hpp/pinocchio/urdf/util.hh>
-#include <pyhpp/pinocchio/urdf/fwd.hh>
+#include <pyhpp/manipulation/fwd.hh>
+#include <pyhpp/util.hh>
 
-using namespace boost::python;
+BOOST_PYTHON_MODULE(bindings) {
+  INIT_PYHPP_MODULE;
 
-namespace pyhpp {
-namespace pinocchio {
-namespace urdf {
-using hpp::pinocchio::DevicePtr_t;
-using namespace hpp::pinocchio::urdf;
-
-void exposeUtil() {
-  def("loadModel", &loadModel);
-  def("loadModelFromString", &loadModelFromString);
+  boost::python::import("pyhpp.pinocchio");
+  pyhpp::manipulation::exposeHandle();
+  pyhpp::manipulation::exposeDevice();
 }
-}  // namespace urdf
-}  // namespace pinocchio
-}  // namespace pyhpp

--- a/src/pyhpp/manipulation/device.cc
+++ b/src/pyhpp/manipulation/device.cc
@@ -18,24 +18,112 @@
 
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
-#include <pinocchio/spatial/se3.hpp>
-#include <hpp/constraints/implicit.hh>
-#include <hpp/manipulation/device.hh>
-#include <hpp/manipulation/handle.hh>
+#include <pyhpp/util.hh>
+
+#include <../src/pyhpp/manipulation/device.hh>
 
 namespace pyhpp {
 namespace manipulation {
 using namespace boost::python;
-using namespace hpp::manipulation;
 
-std::map<std::string, HandlePtr_t> getDeviceHandles(const DevicePtr_t& device)
+Device::Device(const hpp::manipulation::DevicePtr_t& object)
 {
-  return device->handles.map;
+  obj = object;
+}
+Device::Device(const std::string& name) : obj(hpp::manipulation::Device::create(name))
+{
+}
+// Methods from hpp::pinocchio::Device
+const std::string& Device::name() const
+{
+  return obj->name();
+}
+const LiegroupSpacePtr_t& Device::configSpace() const
+{
+  return obj->configSpace();
+}
+Model& Device::model()
+{
+  return obj->model();
+}
+Data& Device::data()
+{
+  return obj->data();
+}
+GeomData& Device::geomData()
+{
+  return obj->geomData();
+}
+GeomModel& Device::geomModel()
+{
+  return obj->geomModel();
+}
+size_type Device::configSize() const
+{
+  return obj->configSize();
+}
+size_type Device::numberDof() const
+{
+  return obj->numberDof();
+}
+const Configuration_t& Device::currentConfiguration() const
+{
+  return obj->currentConfiguration();
+}
+bool Device::currentConfiguration(ConfigurationIn_t configuration)
+{
+  return obj->currentConfiguration(configuration);
+}
+void Device::computeForwardKinematics(int flag) {
+  return obj->computeForwardKinematics(flag);
+}
+void Device::computeFramesForwardKinematics() {
+  return obj->computeFramesForwardKinematics();
+}
+void Device::updateGeometryPlacements() {
+  return obj->updateGeometryPlacements();
+}
+// Methods for hpp::manipulation::Device
+void Device::setRobotRootPosition(const std::string& robotName,
+                          const Transform3s& positionWRTParentJoint)
+{
+  return obj->setRobotRootPosition(robotName, positionWRTParentJoint);
 }
 
-std::map<std::string, GripperPtr_t> getDeviceGrippers(const DevicePtr_t& device)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFrameId_overload, Model::getFrameId,
+                                       1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existFrame_overload, Model::existFrame,
+                                       1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(addJointFrame_overload,
+                                       Model::addJointFrame, 1, 2)
+
+bool Device_currentConfiguration(Device& d, const Configuration_t& c) {
+  return d.currentConfiguration(c);
+}
+
+Transform3s getObjectPositionInJoint(const GripperPtr_t& gripper)
 {
-  return device->grippers.map;
+  Transform3s res(gripper->objectPositionInJoint());
+  return res;
+}
+
+bool check(const Device& device)
+{
+  for (auto const& g: device.obj->grippers.map)
+  {
+    std::cout << g.first << std::endl;
+  }
+  return true;
+}
+
+std::map<std::string, HandlePtr_t> getDeviceHandles(const Device& device)
+{
+  return device.obj->handles.map;
+}
+
+std::map<std::string, GripperPtr_t> getDeviceGrippers(const Device& device)
+{
+  return device.obj->grippers.map;
 }
 
 std::string getHandleName(const HandlePtr_t& handle)
@@ -96,10 +184,32 @@ void exposeHandle() {
     .def(boost::python::map_indexing_suite< std::map<std::string, HandlePtr_t>, true >());
 }
 void exposeDevice() {
+  void (Device::*cfk)(int) = &Device::computeForwardKinematics;
   // Enable automatic conversion of std::map
-  class_<Device, DevicePtr_t, boost::noncopyable, bases<hpp::pinocchio::Device> >("Device", no_init)
-    .def("create", &Device::create)
-    .staticmethod("create")
+  class_<Device>("Device", init <const std::string&> ())
+    .def("name", &Device::name, return_value_policy<return_by_value>())
+    .def("configSpace", &Device::configSpace,
+	 return_value_policy<return_by_value>())
+    .def("model", static_cast<Model& (Device::*)()>(&Device::model),
+	 return_internal_reference<>())
+    .def("data", static_cast<Data& (Device::*)()>(&Device::data),
+	 return_internal_reference<>())
+    .def("geomData", static_cast<GeomData& (Device::*)()>(&Device::geomData),
+	 return_internal_reference<>())
+    .def("geomModel",
+	 static_cast<GeomModel& (Device::*)()>(&Device::geomModel),
+	 return_internal_reference<>())
+    .PYHPP_DEFINE_METHOD(Device, configSize)
+    .PYHPP_DEFINE_METHOD(Device, numberDof)
+    .def("currentConfiguration",
+	 static_cast<const Configuration_t& (Device::*)() const>(
+             &Device::currentConfiguration),
+	 return_value_policy<return_by_value>())
+    .def("currentConfiguration", Device_currentConfiguration)
+    .def("computeForwardKinematics", cfk)
+    .def("computeFramesForwardKinematics",
+	 &Device::computeFramesForwardKinematics)
+    .def("updateGeometryPlacements", &Device::updateGeometryPlacements)
     .def("setRobotRootPosition", &Device::setRobotRootPosition)
     .def("handles", &getDeviceHandles)
     .def("grippers", &getDeviceGrippers);

--- a/src/pyhpp/manipulation/device.cc
+++ b/src/pyhpp/manipulation/device.cc
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <boost/python/suite/indexing/map_indexing_suite.hpp>
+#include <pinocchio/spatial/se3.hpp>
+#include <hpp/constraints/implicit.hh>
+#include <hpp/manipulation/device.hh>
+#include <hpp/manipulation/handle.hh>
+
+namespace pyhpp {
+namespace manipulation {
+using namespace boost::python;
+using namespace hpp::manipulation;
+
+std::map<std::string, HandlePtr_t> getDeviceHandles(const DevicePtr_t& device)
+{
+  return device->handles.map;
+}
+
+std::map<std::string, GripperPtr_t> getDeviceGrippers(const DevicePtr_t& device)
+{
+  return device->grippers.map;
+}
+
+std::string getHandleName(const HandlePtr_t& handle)
+{
+  return handle->name();
+}
+
+void setHandleName(const HandlePtr_t& handle, const std::string& name)
+{
+  handle->name(name);
+}
+
+Transform3s getHandleLocalPosition(const HandlePtr_t& handle)
+{
+  return handle->localPosition();
+}
+
+void setHandleLocalPosition(const HandlePtr_t& handle, const Transform3s& se3)
+{
+  handle->localPosition(se3);
+}
+
+std::vector<bool> getHandleMask(const HandlePtr_t& handle)
+{
+  return handle->mask();
+}
+
+void setHandleMask(const HandlePtr_t& handle, const std::vector<bool>& mask)
+{
+  handle->mask(mask);
+}
+
+std::vector<bool> getHandleMaskComp(const HandlePtr_t& handle)
+{
+  return handle->maskComp();
+}
+
+void setHandleMaskComp(const HandlePtr_t& handle, const std::vector<bool>& mask)
+{
+  handle->maskComp(mask);
+}
+
+void exposeHandle() {
+  class_<Handle, HandlePtr_t>("Handle", no_init)
+    .def("create", &Handle::create)
+    .staticmethod("create")
+    .add_property("name", &getHandleName, &setHandleName)
+    .add_property("localPosition", &getHandleLocalPosition, &setHandleLocalPosition)
+    .add_property("mask", &getHandleMask, &setHandleMask)
+    .add_property("maskComp", &getHandleMaskComp, &setHandleMaskComp)
+    .add_property("clearance",
+		  static_cast<value_type (Handle::*)() const >(&Handle::clearance),
+		  static_cast<void (Handle::*)(const value_type&)>(&Handle::clearance))
+    .def("createGrasp", &Handle::createGrasp)
+    .def("createGraspComplement", &Handle::createGraspComplement)
+    .def("createGraspAndComplement", &Handle::createGraspAndComplement);
+  class_< std::map<std::string, HandlePtr_t> >("HandleMap")
+    .def(boost::python::map_indexing_suite< std::map<std::string, HandlePtr_t>, true >());
+}
+void exposeDevice() {
+  // Enable automatic conversion of std::map
+  class_<Device, DevicePtr_t, boost::noncopyable, bases<hpp::pinocchio::Device> >("Device", no_init)
+    .def("create", &Device::create)
+    .staticmethod("create")
+    .def("setRobotRootPosition", &Device::setRobotRootPosition)
+    .def("handles", &getDeviceHandles)
+    .def("grippers", &getDeviceGrippers);
+}
+} // namespace manipulation
+} // namespace pyhpp

--- a/src/pyhpp/manipulation/device.hh
+++ b/src/pyhpp/manipulation/device.hh
@@ -44,9 +44,10 @@ typedef hpp::pinocchio::Computation_t Computation_t;
 typedef hpp::manipulation::HandlePtr_t HandlePtr_t;
 typedef hpp::manipulation::Handle Handle;
 
-// Create a class Device that wraps a hpp::manipulation::Device
-HPP_PREDEF_CLASS(Device);
-typedef std::shared_ptr<Device> DevicePtr_t;
+// Wrapper class to hpp::manipulation::Device
+//
+// Boost python does not correctly handle weak pointers. To overcome this limitation,
+// we create a wrapper class and bind this class with boost python instead of the original class.
 struct Device {
   hpp::manipulation::DevicePtr_t obj;
   Device(const hpp::manipulation::DevicePtr_t& object);

--- a/src/pyhpp/manipulation/device.hh
+++ b/src/pyhpp/manipulation/device.hh
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <pinocchio/multibody/data.hpp>
+#include <pinocchio/multibody/geometry.hpp>
+#include <pinocchio/spatial/se3.hpp>
+#include <hpp/pinocchio/gripper.hh>
+#include <hpp/constraints/implicit.hh>
+#include <hpp/manipulation/device.hh>
+#include <hpp/manipulation/handle.hh>
+
+namespace pyhpp {
+namespace manipulation {
+
+typedef hpp::pinocchio::Model Model;
+typedef hpp::pinocchio::Data Data;
+typedef hpp::pinocchio::ModelPtr_t ModelPtr_t;
+typedef hpp::pinocchio::GeomData GeomData;
+typedef hpp::pinocchio::LiegroupSpacePtr_t LiegroupSpacePtr_t;
+typedef hpp::pinocchio::GeomModel GeomModel;
+typedef hpp::pinocchio::Configuration_t Configuration_t;
+typedef hpp::pinocchio::ConfigurationIn_t ConfigurationIn_t;
+typedef hpp::pinocchio::size_type size_type;
+typedef hpp::pinocchio::value_type value_type;
+typedef hpp::pinocchio::Transform3s Transform3s;
+typedef hpp::pinocchio::GripperPtr_t GripperPtr_t;
+typedef hpp::pinocchio::Gripper Gripper;
+typedef hpp::pinocchio::Computation_t Computation_t;
+typedef hpp::manipulation::HandlePtr_t HandlePtr_t;
+typedef hpp::manipulation::Handle Handle;
+
+// Create a class Device that wraps a hpp::manipulation::Device
+HPP_PREDEF_CLASS(Device);
+typedef std::shared_ptr<Device> DevicePtr_t;
+struct Device {
+  hpp::manipulation::DevicePtr_t obj;
+  Device(const hpp::manipulation::DevicePtr_t& object);
+  Device(const std::string& name);
+  // Methods from hpp::pinocchio::Device
+  const std::string& name() const;
+  const LiegroupSpacePtr_t& configSpace() const;
+  Model& model();
+  Data& data();
+  GeomData& geomData();
+  GeomModel& geomModel();
+  size_type configSize() const;
+  size_type numberDof() const;
+  const Configuration_t& currentConfiguration() const;
+  bool currentConfiguration(ConfigurationIn_t configuration);
+  void computeForwardKinematics(int flag);
+  void computeFramesForwardKinematics();
+  void updateGeometryPlacements();
+  // Methods for hpp::manipulation::Device
+  void setRobotRootPosition(const std::string& robotName,
+                            const Transform3s& positionWRTParentJoint);
+}; // struct Device
+} // namespace manipulation
+} // namespace pyhpp

--- a/src/pyhpp/manipulation/graph.cc
+++ b/src/pyhpp/manipulation/graph.cc
@@ -1,0 +1,214 @@
+//
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <pinocchio/spatial/se3.hpp>
+#include <hpp/manipulation/graph/edge.hh>
+#include <hpp/manipulation/graph/graph.hh>
+#include <hpp/manipulation/graph/state.hh>
+#include <hpp/manipulation/graph/state-selector.hh>
+
+#include <../src/pyhpp/manipulation/device.hh>
+#include <../src/pyhpp/manipulation/graph.hh>
+
+namespace pyhpp {
+namespace manipulation {
+
+typedef hpp::manipulation::size_type size_type;
+typedef hpp::manipulation::value_type value_type;
+typedef hpp::manipulation::graph::GraphComponent GraphComponent;
+typedef hpp::manipulation::graph::GraphComponentPtr_t GraphComponentPtr_t;
+typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
+typedef hpp::manipulation::graph::Edge Edge;
+typedef hpp::manipulation::graph::EdgePtr_t EdgePtr_t;
+typedef hpp::manipulation::graph::State State;
+typedef hpp::manipulation::graph::StatePtr_t StatePtr_t;
+
+template <typename T>
+std::string toStr() {
+  return typeid(T).name();
+}
+template <>
+std::string toStr<hpp::manipulation::graph::State>() {
+  return "State";
+}
+template <>
+std::string toStr<hpp::manipulation::graph::Edge>() {
+  return "Transition";
+}
+template <>
+std::string toStr<hpp::manipulation::graph::Graph>() {
+  return "Graph";
+}
+template <>
+std::string toStr<hpp::manipulation::graph::LevelSetEdge>() {
+  return "LevelSetTransition";
+}
+template <>
+std::string toStr<hpp::manipulation::graph::WaypointEdge>() {
+  return "WaypointTransition";
+}
+
+template <typename T>
+std::shared_ptr<T> Graph::getComp(const std::string& name) {
+  std::shared_ptr<T> comp;
+  try {
+    auto it(id.find(name));
+    if (it == id.end()) {
+      std::stringstream ss;
+      ss << "\"" << name << "\" is not a " << toStr<T>();
+      throw std::logic_error(ss.str().c_str());
+    }
+    comp = HPP_DYNAMIC_PTR_CAST(T, obj->get(it->second).lock());
+  } catch (std::out_of_range& e) {
+    throw std::logic_error(e.what());
+  }
+  if (!comp) {
+    std::stringstream ss;
+    ss << "\"" << name << "\" is not a " << toStr<T>();
+    throw std::logic_error(ss.str().c_str());
+  }
+  return comp;
+}
+
+// Wrapper class to hpp::manipulation::graph::Graph
+//
+// Boost python does not correctly handle weak pointers. To overcome this limitation,
+// we create a wrapper class and bind this class with boost python instead of the original class.
+Graph::Graph(const hpp::manipulation::graph::GraphPtr_t& object) : obj(object) {
+}
+Graph::Graph(const std::string& name, const Device& d, const ProblemPtr_t& problem) :
+  obj(hpp::manipulation::graph::Graph::create(name, d.obj, problem)) {
+}
+
+std::string Graph::name() const {
+  return obj->name();
+}
+
+std::size_t Graph::createState(const std::string& nodeName, bool waypoint, int priority) {
+  hpp::manipulation::graph::GraphPtr_t graph = obj;
+  if (graph->stateSelector()) {
+    hpp::manipulation::graph::StatePtr_t state =
+      graph->stateSelector()->createState(nodeName, waypoint, priority);
+    id[nodeName] = state->id();
+    return state->id();
+  } else {
+    throw std::logic_error("Graph has no state selector.");
+  }
+}
+
+std::size_t Graph::createTransition(const std::string& nodeFrom, const std::string& nodeTo,
+				    const std::string& transitionName, int w,
+				    const std::string& isInState) {
+  using namespace hpp::manipulation::graph;
+  StatePtr_t from = getComp<State>(nodeFrom),
+    to = getComp<State>(nodeTo),
+    inState = getComp<State>(isInState);
+
+  EdgePtr_t edge = from->linkTo(transitionName, to, w,
+                                (State::EdgeFactory)Edge::create);
+  edge->state(inState);
+
+  return (std::size_t)edge->id();
+}
+
+void Graph::addNumericalConstraint(const std::string& name,
+				   const ImplicitPtr_t& constraint) {
+  using namespace hpp::manipulation::graph;
+  GraphComponentPtr_t component =
+      getComp<GraphComponent>(name);
+  component->addNumericalConstraint(constraint);
+}
+
+hpp::constraints::NumericalConstraints_t Graph::getNumericalConstraints(const std::string& name) {
+  using namespace hpp::manipulation::graph;
+  GraphComponentPtr_t component =
+      getComp<GraphComponent>(name);
+  return component->numericalConstraints();
+}
+
+std::tuple<bool, Configuration_t, value_type> Graph::applyStateConstraints
+  (const std::string& nodeName, ConfigurationIn_t input){
+  using namespace hpp::manipulation;
+  // Recover state from name
+  graph::StatePtr_t state = getComp<graph::State>(nodeName);
+  ConstraintSetPtr_t constraint(state->configConstraint());
+  value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
+  Configuration_t output(input);
+  bool success(constraint->apply(output));
+  if (hpp::core::ConfigProjectorPtr_t configProjector = constraint->configProjector()) {
+    residualError = configProjector->residualError();
+  }
+  return std::make_tuple(success, output, residualError);
+}
+
+std::tuple<bool, Configuration_t, value_type> Graph::applyLeafConstraints
+(const std::string& transitionName, ConfigurationIn_t q_rhs, ConfigurationIn_t input)
+{
+  using namespace hpp::manipulation;
+  // Recover state from name
+  graph::EdgePtr_t transition = getComp<graph::Edge>(transitionName);
+  ConstraintSetPtr_t constraint(transition->pathConstraint());
+  value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
+  Configuration_t output(input);
+  bool success(true);
+  if (constraint->configProjector()) {
+    constraint->configProjector()->rightHandSideFromConfig(q_rhs);
+    success = constraint->apply(output);
+    residualError = constraint->configProjector()->residualError();
+  } else {
+    residualError = std::numeric_limits<value_type>::quiet_NaN();
+  }
+  return std::make_tuple(success, output, residualError);
+}
+
+std::tuple<bool, Configuration_t, value_type> Graph::generateTargetConfig
+(const std::string& transitionName, ConfigurationIn_t q_rhs, ConfigurationIn_t input)
+{
+  using namespace hpp::manipulation;
+  // Recover state from name
+  graph::EdgePtr_t transition = getComp<graph::Edge>(transitionName);
+  ConstraintSetPtr_t constraint(transition->targetConstraint());
+  value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
+  Configuration_t output(input);
+  bool success(true);
+  if (constraint->configProjector()) {
+    constraint->configProjector()->rightHandSideFromConfig(q_rhs);
+    success = constraint->apply(output);
+    residualError = constraint->configProjector()->residualError();
+  } else {
+    residualError = std::numeric_limits<value_type>::quiet_NaN();
+  }
+  return std::make_tuple(success, output, residualError);
+}
+
+using namespace boost::python;
+
+void exposeGraph() {
+  class_<Graph>("Graph", init <const std::string&, const Device&, const ProblemPtr_t&> ())
+    .def_readonly("name", &Graph::name)
+    .def("createState", &Graph::createState)
+    .def("createTransition", &Graph::createTransition)
+    .def("addNumericalConstraint", &Graph::addNumericalConstraint)
+    .def("getNumericalConstraints", &Graph::getNumericalConstraints)
+    .def("applyStateConstraints", &Graph::applyStateConstraints)
+    .def("applyLeafConstraints", &Graph::applyLeafConstraints)
+    .def("generateTargetConfig", &Graph::generateTargetConfig);
+}
+} // namespace manipulation
+} // namespace pyhpp

--- a/src/pyhpp/manipulation/graph.hh
+++ b/src/pyhpp/manipulation/graph.hh
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+namespace pyhpp {
+namespace manipulation {
+
+typedef hpp::manipulation::size_type size_type;
+typedef hpp::manipulation::value_type value_type;
+typedef hpp::manipulation::graph::GraphComponent GraphComponent;
+typedef hpp::manipulation::graph::GraphComponentPtr_t GraphComponentPtr_t;
+typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
+typedef hpp::manipulation::graph::Edge Edge;
+typedef hpp::manipulation::graph::EdgePtr_t EdgePtr_t;
+typedef hpp::manipulation::graph::State State;
+typedef hpp::manipulation::graph::StatePtr_t StatePtr_t;
+
+struct Graph {
+  typedef hpp::constraints::ImplicitPtr_t ImplicitPtr_t;
+  typedef hpp::constraints::NumericalConstraints_t NumericalConstraints_t;
+  // Pointer to the underlying object
+  hpp::manipulation::graph::GraphPtr_t obj;
+  // Map from name to id
+  std::map <std::string, std::size_t> id;
+  // Get shared pointer to object from name among (Graph, Node, Edge)
+  template <typename T>
+  std::shared_ptr<T> getComp(const std::string& name);
+  // Constructor with a pointer to underlying graph
+  Graph(const hpp::manipulation::graph::GraphPtr_t& object);
+  // Constructor exposed in python
+  Graph(const std::string& name, const Device& d, const ProblemPtr_t& problem);
+  // Get name of the graph
+  std::string name() const;
+  // Create a state in the graph
+  std::size_t createState(const std::string& nodeName, bool waypoint, int priority);
+  // Create a transition between two states in the graph
+  std::size_t createTransition(const std::string& nodeFrom, const std::string& nodeTo,
+			       const std::string& transitionName, int w,
+			       const std::string& isInState);
+  // Add numerical constraints to a graph, a state or a transition
+  void addNumericalConstraint(const std::string& name,
+			      const ImplicitPtr_t& constraint);
+  // Get numerical constraints of a graph, a state or a transition
+  NumericalConstraints_t getNumericalConstraints(const std::string& name);
+  // Project a configuration on a state
+  std::tuple<bool, Configuration_t, value_type> applyStateConstraints
+  (const std::string& nodeName, ConfigurationIn_t input);
+  // Project configuration on the leaf of a transition
+  std::tuple<bool, Configuration_t, value_type> applyLeafConstraints
+  (const std::string& transitionName, ConfigurationIn_t q_rhs, ConfigurationIn_t input);
+  // Project configuration at intersection of a leaf and the goal state of a trnasition
+  std::tuple<bool, Configuration_t, value_type> generateTargetConfig
+  (const std::string& transitionName, ConfigurationIn_t q_rhs, ConfigurationIn_t input);
+}; // class Graph
+} // namespace manipulation
+} // namespace pyhpp

--- a/src/pyhpp/manipulation/problem.cc
+++ b/src/pyhpp/manipulation/problem.cc
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+
+#include <hpp/manipulation/problem.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace manipulation {
+
+typedef hpp::manipulation::Problem Problem;
+typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
+typedef hpp::manipulation::ProblemConstPtr_t ProblemConstPtr_t;
+
+void exposeProblem() {
+  register_ptr_to_python<ProblemConstPtr_t>();
+  implicitly_convertible<ProblemPtr_t, ProblemConstPtr_t>();
+  class_<Problem, ProblemPtr_t, boost::noncopyable, bases <hpp::core::Problem> >
+    ("Problem", no_init).
+    def("create", &Problem::create).staticmethod("create");
+}
+} // manipulation
+} // pyhpp

--- a/src/pyhpp/manipulation/urdf/bindings.cc
+++ b/src/pyhpp/manipulation/urdf/bindings.cc
@@ -1,6 +1,7 @@
 //
-// Copyright (c) 2018 - 2023, CNRS
-// Authors: Joseph Mirabel, Florent Lamiraux
+// Copyright (c) 2025 CNRS
+// Authors: Florent Lamiraux
+//
 //
 // This file is part of hpp-python
 // hpp-python is free software: you can redistribute it
@@ -17,21 +18,11 @@
 // <http://www.gnu.org/licenses/>.
 
 #include <boost/python.hpp>
-#include <hpp/pinocchio/urdf/util.hh>
-#include <pyhpp/pinocchio/urdf/fwd.hh>
+#include <pyhpp/manipulation/urdf/fwd.hh>
+#include <pyhpp/util.hh>
 
-using namespace boost::python;
+BOOST_PYTHON_MODULE(bindings) {
+  INIT_PYHPP_MODULE;
 
-namespace pyhpp {
-namespace pinocchio {
-namespace urdf {
-using hpp::pinocchio::DevicePtr_t;
-using namespace hpp::pinocchio::urdf;
-
-void exposeUtil() {
-  def("loadModel", &loadModel);
-  def("loadModelFromString", &loadModelFromString);
+  pyhpp::manipulation::urdf::exposeUtil();
 }
-}  // namespace urdf
-}  // namespace pinocchio
-}  // namespace pyhpp

--- a/src/pyhpp/manipulation/urdf/util.cc
+++ b/src/pyhpp/manipulation/urdf/util.cc
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2025, CNRS
+// Authors: Florent Lamiraux
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/pinocchio/urdf/util.hh>
+#include <hpp/manipulation/device.hh>
+#include <hpp/manipulation/srdf/util.hh>
+#include <pyhpp/pinocchio/urdf/fwd.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace manipulation {
+namespace urdf {
+using hpp::manipulation::DevicePtr_t;
+using ::pinocchio::FrameIndex;
+using ::pinocchio::SE3;
+
+// Redefine loadModel in order to parse the srdf file with hpp-manipulation-urdf
+void loadModel(const DevicePtr_t& robot, const FrameIndex& baseFrame,
+	       const std::string& prefix, const std::string& rootType,
+	       const std::string& urdfPath, const std::string& srdfPath,
+	       const SE3& bMr)
+{
+  hpp::pinocchio::urdf::loadModel(robot, baseFrame, prefix, rootType, urdfPath, srdfPath, bMr);
+  if (!std::string(srdfPath).empty()) {
+    hpp::manipulation::srdf::loadModelFromFile(robot, prefix, srdfPath);
+  }
+}
+
+void loadModelFromString(const DevicePtr_t& robot, const FrameIndex& baseFrame,
+                         const std::string& prefix, const std::string& rootType,
+                         const std::string& urdfString,
+                         const std::string& srdfString,
+                         const SE3& bMr)
+{
+  hpp::pinocchio::urdf::loadModelFromString(robot, baseFrame, prefix, rootType, urdfString,
+					    srdfString, bMr);
+  hpp::manipulation::srdf::loadModelFromXML(robot, prefix, srdfString);
+}
+
+void exposeUtil() {
+  def("loadModel", &loadModel);
+  def("loadModelFromString", &loadModelFromString);
+}
+}  // namespace urdf
+}  // namespace manipulation
+}  // namespace pyhpp

--- a/src/pyhpp/manipulation/urdf/util.cc
+++ b/src/pyhpp/manipulation/urdf/util.cc
@@ -22,6 +22,8 @@
 #include <hpp/manipulation/srdf/util.hh>
 #include <pyhpp/pinocchio/urdf/fwd.hh>
 
+#include <../src/pyhpp/manipulation/device.hh>
+
 using namespace boost::python;
 
 namespace pyhpp {
@@ -32,26 +34,26 @@ using ::pinocchio::FrameIndex;
 using ::pinocchio::SE3;
 
 // Redefine loadModel in order to parse the srdf file with hpp-manipulation-urdf
-void loadModel(const DevicePtr_t& robot, const FrameIndex& baseFrame,
+void loadModel(const Device& robot, const FrameIndex& baseFrame,
 	       const std::string& prefix, const std::string& rootType,
 	       const std::string& urdfPath, const std::string& srdfPath,
 	       const SE3& bMr)
 {
-  hpp::pinocchio::urdf::loadModel(robot, baseFrame, prefix, rootType, urdfPath, srdfPath, bMr);
+  hpp::pinocchio::urdf::loadModel(robot.obj, baseFrame, prefix, rootType, urdfPath, srdfPath, bMr);
   if (!std::string(srdfPath).empty()) {
-    hpp::manipulation::srdf::loadModelFromFile(robot, prefix, srdfPath);
+    hpp::manipulation::srdf::loadModelFromFile(robot.obj, prefix, srdfPath);
   }
 }
 
-void loadModelFromString(const DevicePtr_t& robot, const FrameIndex& baseFrame,
+void loadModelFromString(const Device& robot, const FrameIndex& baseFrame,
                          const std::string& prefix, const std::string& rootType,
                          const std::string& urdfString,
                          const std::string& srdfString,
                          const SE3& bMr)
 {
-  hpp::pinocchio::urdf::loadModelFromString(robot, baseFrame, prefix, rootType, urdfString,
+  hpp::pinocchio::urdf::loadModelFromString(robot.obj, baseFrame, prefix, rootType, urdfString,
 					    srdfString, bMr);
-  hpp::manipulation::srdf::loadModelFromXML(robot, prefix, srdfString);
+  hpp::manipulation::srdf::loadModelFromXML(robot.obj, prefix, srdfString);
 }
 
 void exposeUtil() {

--- a/src/pyhpp/pinocchio/bindings.cc
+++ b/src/pyhpp/pinocchio/bindings.cc
@@ -27,5 +27,6 @@ BOOST_PYTHON_MODULE(bindings) {
   boost::python::import("pinocchio");
 
   pyhpp::pinocchio::exposeDevice();
+  pyhpp::pinocchio::exposeGripper();
   pyhpp::pinocchio::exposeLiegroup();
 }

--- a/src/pyhpp/pinocchio/device.cc
+++ b/src/pyhpp/pinocchio/device.cc
@@ -41,11 +41,24 @@ using namespace boost::python;
 
 namespace pyhpp {
 namespace pinocchio {
-using namespace hpp::pinocchio;
 
 namespace bp = boost::python;
 typedef hpp::pinocchio::Model Model;
+typedef hpp::pinocchio::Data Data;
 typedef hpp::pinocchio::ModelPtr_t ModelPtr_t;
+typedef hpp::pinocchio::GeomData GeomData;
+typedef hpp::pinocchio::LiegroupSpacePtr_t LiegroupSpacePtr_t;
+typedef hpp::pinocchio::GeomModel GeomModel;
+typedef hpp::pinocchio::Configuration_t Configuration_t;
+typedef hpp::pinocchio::ConfigurationIn_t ConfigurationIn_t;
+typedef hpp::pinocchio::size_type size_type;
+typedef hpp::pinocchio::Transform3s Transform3s;
+typedef hpp::pinocchio::Device Device;
+typedef hpp::pinocchio::DevicePtr_t DevicePtr_t;
+typedef hpp::pinocchio::GripperPtr_t GripperPtr_t;
+typedef hpp::pinocchio::Gripper Gripper;
+typedef hpp::pinocchio::Computation_t Computation_t;
+
 using namespace boost::python;
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFrameId_overload, Model::getFrameId,
@@ -75,12 +88,12 @@ void exposeGripper() {
 }
 void exposeDevice() {
   enum_<Computation_t>("ComputationFlag")
-      .value("JOINT_POSITION", JOINT_POSITION)
-      .value("JACOBIAN", JACOBIAN)
-      .value("VELOCITY", VELOCITY)
-      .value("ACCELERATION", ACCELERATION)
-      .value("COM", COM)
-      .value("COMPUTE_ALL", COMPUTE_ALL);
+      .value("JOINT_POSITION", hpp::pinocchio::JOINT_POSITION)
+      .value("JACOBIAN", hpp::pinocchio::JACOBIAN)
+      .value("VELOCITY", hpp::pinocchio::VELOCITY)
+      .value("ACCELERATION", hpp::pinocchio::ACCELERATION)
+      .value("COM", hpp::pinocchio::COM)
+      .value("COMPUTE_ALL", hpp::pinocchio::COMPUTE_ALL);
   void (Device::*cfk)(int) = &Device::computeForwardKinematics;
   class_<Device, DevicePtr_t, boost::noncopyable>("Device", no_init)
       .def("name", &Device::name, return_value_policy<return_by_value>())

--- a/src/pyhpp/pinocchio/device.cc
+++ b/src/pyhpp/pinocchio/device.cc
@@ -17,9 +17,11 @@
 // <http://www.gnu.org/licenses/>.
 
 #include <boost/python.hpp>
+#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <hpp/pinocchio/device-data.hh>
 #include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/gripper.hh>
 #include <hpp/pinocchio/liegroup-space.hh>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/multibody/geometry.hpp>
@@ -44,8 +46,8 @@ using namespace hpp::pinocchio;
 namespace bp = boost::python;
 typedef hpp::pinocchio::Model Model;
 typedef hpp::pinocchio::ModelPtr_t ModelPtr_t;
-using boost::python::class_;
-using boost::python::no_init;
+using namespace boost::python;
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFrameId_overload, Model::getFrameId,
                                        1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existFrame_overload, Model::existFrame,
@@ -57,6 +59,20 @@ bool Device_currentConfiguration(Device& d, const Configuration_t& c) {
   return d.currentConfiguration(c);
 }
 
+Transform3s getObjectPositionInJoint(const GripperPtr_t& gripper)
+{
+  Transform3s res(gripper->objectPositionInJoint());
+  return res;
+}
+
+void exposeGripper() {
+  class_<Gripper, GripperPtr_t>("Gripper", no_init)
+    .def("create", &Gripper::create)
+    .staticmethod("create")
+    .add_property("localPosition", &getObjectPositionInJoint);
+  class_< std::map<std::string, GripperPtr_t> >("GripperMap")
+    .def(boost::python::map_indexing_suite< std::map<std::string, GripperPtr_t>, true >());
+}
 void exposeDevice() {
   enum_<Computation_t>("ComputationFlag")
       .value("JOINT_POSITION", JOINT_POSITION)

--- a/tests/construction_set.py
+++ b/tests/construction_set.py
@@ -1,10 +1,10 @@
 from math import pi
 import numpy as np
 from pinocchio import SE3
-from pyhpp.manipulation import Device, urdf
+from pyhpp.pinocchio import Device, urdf
 from pyhpp.gepetto import Viewer
 
-robot = Device("construction-set")
+robot = Device.create("construction_set")
 
 #Create viewer
 viewer = Viewer("construction_set", robot)

--- a/tests/construction_set.py
+++ b/tests/construction_set.py
@@ -2,21 +2,33 @@ from math import pi
 import numpy as np
 from pinocchio import SE3
 from pyhpp.manipulation import Device, urdf
+from pyhpp.gepetto import Viewer
+
+robot = Device("construction-set")
+
+#Create viewer
+viewer = Viewer("construction_set", robot)
 
 # Load two UR3 robots
 urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
 srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
 
 r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
-r1_pose = SE3(rotation = np.identity(3), translation = np.array([ 0.25, 0, 0]))
-robot = Device.create("construction-set")
-urdf.loadModel(robot, 0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
-urdf.loadModel(robot, 0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
+r1_pose = SE3(rotation = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]]), translation = np.array([ 0.25, 0, 0]))
+
+#urdf.loadModel(robot, 0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
+#urdf.loadModel(robot, 0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
+viewer.addURDFToScene(0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
+viewer.addURDFToScene(0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
 
 # Load environment
 urdfFilename = "package://hpp_environments/urdf/construction_set/ground.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/ground.srdf"
-urdf.loadModel(robot, 0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+#urdf.loadModel(robot, 0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+viewer.addURDFToScene(0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+
+q = np.array([pi/6, -pi/2, pi/2, 0, 0, 0,] + [pi/6, -pi/2, pi/2, 0, 0, 0,])
+viewer.applyConfiguration(q)
 
 # Load spheres
 nSphere = 2
@@ -26,15 +38,16 @@ objects = list ()
 urdfFilename = "package://hpp_environments/urdf/construction_set/sphere.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/sphere.srdf"
 for i in range (nSphere):
-    urdf.loadModel(robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
+    #urdf.loadModel(robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
+    viewer.addURDFToScene(0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
     objects.append (f"sphere{i}")
 
 # Load cylinders
 urdfFilename = "package://hpp_environments/urdf/construction_set/cylinder_08.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/cylinder_08.srdf"
 for i in range (nCylinder):
-    urdf.loadModel(robot, 0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,
-                   SE3.Identity())
+    #urdf.loadModel(robot, 0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,SE3.Identity())
+    viewer.addURDFToScene(0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,SE3.Identity())
     objects.append (f"cylinder{i}")
 
 # Set joint bounds

--- a/tests/construction_set.py
+++ b/tests/construction_set.py
@@ -1,0 +1,85 @@
+from math import pi
+import numpy as np
+from pinocchio import SE3
+from pyhpp.manipulation import Device, urdf
+
+# Load two UR3 robots
+urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
+srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
+
+r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
+r1_pose = SE3(rotation = np.identity(3), translation = np.array([ 0.25, 0, 0]))
+robot = Device.create("construction-set")
+urdf.loadModel(robot, 0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
+urdf.loadModel(robot, 0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
+
+# Load environment
+urdfFilename = "package://hpp_environments/urdf/construction_set/ground.urdf"
+srdfFilename = "package://hpp_environments/srdf/construction_set/ground.srdf"
+urdf.loadModel(robot, 0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+
+# Load spheres
+nSphere = 2
+nCylinder = 2
+
+objects = list ()
+urdfFilename = "package://hpp_environments/urdf/construction_set/sphere.urdf"
+srdfFilename = "package://hpp_environments/srdf/construction_set/sphere.srdf"
+for i in range (nSphere):
+    urdf.loadModel(robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
+    objects.append (f"sphere{i}")
+
+# Load cylinders
+urdfFilename = "package://hpp_environments/urdf/construction_set/cylinder_08.urdf"
+srdfFilename = "package://hpp_environments/srdf/construction_set/cylinder_08.srdf"
+for i in range (nCylinder):
+    urdf.loadModel(robot, 0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,
+                   SE3.Identity())
+    objects.append (f"cylinder{i}")
+
+# Set joint bounds
+# Set robot joint bounds
+jointBounds =  {'r0/shoulder_pan_joint': [-pi, 4],
+                'r1/shoulder_pan_joint': [-pi, 4],
+                'r0/shoulder_lift_joint': [-pi, 0],
+                'r1/shoulder_lift_joint': [-pi, 0],
+                'r0/elbow_joint': [-2.6, 2.6],
+                'r1/elbow_joint': [-2.6, 2.6]}
+m = robot.model()
+lowerLimit = m.lowerPositionLimit
+upperLimit = m.upperPositionLimit
+for jn, [lower, upper] in jointBounds.items():
+    lowerLimit[m.getJointId(jn)] = lower
+    upperLimit[m.getJointId(jn)] = upper
+
+for i in range (nSphere):
+    ij = m.getJointId(f"sphere{i}/root_joint")
+    iq = m.idx_qs[ij]
+    nq = m.nqs[ij]
+    lowerLimit[iq:iq+nq] = \
+               [-1., -1., -.1, -1.0001, -1.0001, -1.0001, -1.0001]
+    upperLimit[iq:iq+nq] = \
+               [ 1.,  1.,  .1,  1.0001,  1.0001,  1.0001,  1.0001]
+
+for i in range (nCylinder):
+    ij = m.getJointId(f"cylinder{i}/root_joint")
+    iq = m.idx_qs[ij]
+    nq = m.nqs[ij]
+    lowerLimit[iq:iq+nq] = \
+               [-1., -1., -.1, -1.0001, -1.0001, -1.0001, -1.0001]
+    upperLimit[iq:iq+nq] = \
+               [ 1.,  1.,  .1,  1.0001,  1.0001,  1.0001,  1.0001]
+
+m.lowerPositionLimit = lowerLimit
+m.upperPositionLimit = upperLimit
+
+grippers = robot.grippers()
+grippers["r0/gripper"].localPosition
+
+handles = robot.handles()
+handles["sphere0/magnet"].localPosition
+
+h = handles["sphere1/magnet"]
+g = grippers["cylinder0/magnet1"]
+
+c = h.createGrasp(g, "sphere1/magnet grasps cylinder0/magnet1")

--- a/tests/load_ur3.py
+++ b/tests/load_ur3.py
@@ -4,15 +4,11 @@ from pinocchio import StdVec_Bool as Mask
 from pyhpp.constraints import Position
 from pyhpp.pinocchio import Device, LiegroupElement, urdf
 
+urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
+srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
+
 robot = Device.create("ur3")
-urdf.loadRobotModel(
-    robot,
-    "anchor",
-    "example-robot-data/robots/ur_description",
-    "ur3",
-    "_gripper",
-    "_gripper",
-)
+urdf.loadModel(robot, 0, "", "anchor", urdfFilename, srdfFilename, SE3.Identity())
 
 q = robot.currentConfiguration()
 robot.currentConfiguration(q)

--- a/tests/motion_planner.py
+++ b/tests/motion_planner.py
@@ -1,0 +1,67 @@
+class MotionPlanner:
+    def __init__(self, robot, ps):
+        self.robot = robot
+        self.ps = ps
+
+    def solveBiRRT(self, maxIter=float("inf")):
+        self.ps.prepareSolveStepByStep()
+        finished = False
+
+        # In the framework of the course,
+        # we restrict ourselves to 2 connected components.
+        nbCC = self.ps.numberConnectedComponents()
+        if nbCC != 2:
+            raise Exception("There should be 2 connected components.")
+
+        iter = 0
+        ps = self.ps
+        robot = self.robot
+        while True:
+            # RRT begin
+            # Extend
+            newNodes = list()
+            newEdges = list()
+            q_rand = robot.shootRandomConfig()
+            for i in range(ps.numberConnectedComponents()):
+                q_near, d = ps.getNearestConfig(q_rand,i)
+                res, pid, msg = ps.directPath(q_near, q_rand, True)
+                if res:
+                    q_new = q_rand
+                else:
+                    q_new = ps.configAtParam(pid, ps.pathLength(pid))
+                newNodes.append(q_new)
+                newEdges.append((q_near, q_new, pid))
+            for q in newNodes:
+                ps.addConfigToRoadmap(q)
+            for q1, q2, pid in newEdges:
+                ps.addEdgeToRoadmap(q1, q2, pid, True)
+            # connect
+            for q_new in newNodes:
+                for i in range(ps.numberConnectedComponents()):
+                    q_near, d = ps.getNearestConfig(q_new, i)
+                    # if q_near == q_new, q_new is in this connected component
+                    if q_near != q_new:
+                        res, pid, msg = ps.directPath(q_new, q_near, True)
+                        if res:
+                            ps.addEdgeToRoadmap(q_new, q_near, pid, True)
+                            print('finished')
+                            break
+            # RRT end
+            # Check if the problem is solved.
+            nbCC = self.ps.numberConnectedComponents()
+            if nbCC == 1:
+                # Problem solved
+                finished = True
+                break
+            iter = iter + 1
+            if iter > maxIter:
+                break
+        if finished:
+            self.ps.finishSolveStepByStep()
+            return self.ps.numberPaths() - 1
+
+    def solvePRM(self):
+        self.ps.prepareSolveStepByStep()
+        # PRM begin
+        # PRM end
+        self.ps.finishSolveStepByStep()

--- a/tests/rrt.py
+++ b/tests/rrt.py
@@ -3,6 +3,7 @@ from pyhpp.gepetto import Viewer
 import numpy as np
 from pinocchio import SE3
 from pyhpp.pinocchio import Device, urdf
+from pyhpp.core import Problem
 
 urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur5_joint_limited_robot.urdf"
 srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur5_joint_limited_robot.srdf"
@@ -12,6 +13,14 @@ robot = Device.create("ur5")
 viewer = Viewer("construction_set", robot)
 
 viewer.addURDFToScene(0, "r0", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+
+viewer.addURDFObstacleToScene("package://hpp_practicals/urdf/ur_benchmark/obstacles.urdf", "obstacles")
+viewer.addURDFObstacleToScene("package://hpp_practicals/urdf/ur_benchmark/table.urdf", "table")
+viewer.addURDFObstacleToScene("package://hpp_practicals/urdf/ur_benchmark/wall.urdf", "wall")
+
+q2 = np.array([0.2, -1.57, -1.8, 0, 0.8, 0])
+
+viewer.applyConfiguration(q2)
 
 
 # vf.loadObstacleModel(
@@ -30,3 +39,60 @@ viewer.addURDFToScene(0, "r0", "anchor", urdfFilename, srdfFilename, SE3.Identit
 
 # m = MotionPlanner(robot, ps)
 # pathId = m.solveBiRRT(maxIter=1000)
+
+#############RRT############
+#def solveBiRRT(self, maxIter=float("inf")):
+#    #cpp#
+#    initProblem();
+#    pathPlanner_->startSolve();
+#    pathPlanner_->tryConnectInitAndGoals();
+#    roadmap_->pathExists();
+#    #cpp#
+#    finished = False
+#    iter = 0
+#    ps = self.ps
+#    while True:
+#        # RRT begin
+#        # Extend
+#        newNodes = list()
+#        newEdges = list()
+#        q_rand = robot.shootRandomConfig()
+#        for i in range(ps.numberConnectedComponents()):
+#            q_near, d = ps.getNearestConfig(q_rand,i)
+#            res, pid, msg = ps.directPath(q_near, q_rand, True)
+#            if res:
+#                q_new = q_rand
+#            else:
+#                q_new = ps.configAtParam(pid, ps.pathLength(pid))
+#            newNodes.append(q_new)
+#            newEdges.append((q_near, q_new, pid))
+#        for q in newNodes:
+#            ps.addConfigToRoadmap(q)
+#        for q1, q2, pid in newEdges:
+#            ps.addEdgeToRoadmap(q1, q2, pid, True)
+#        # connect
+#        for q_new in newNodes:
+#            for i in range(ps.numberConnectedComponents()):
+#                q_near, d = ps.getNearestConfig(q_new, i)
+#                # if q_near == q_new, q_new is in this connected component
+#                if q_near != q_new:
+#                    res, pid, msg = ps.directPath(q_new, q_near, True)
+#                    if res:
+#                        ps.addEdgeToRoadmap(q_new, q_near, pid, True)
+#                        print('finished')
+#                        break
+#        # RRT end
+#        # Check if the problem is solved.
+#        nbCC = self.ps.numberConnectedComponents()
+#        if nbCC == 1:
+#            # Problem solved
+#            finished = True
+#            break
+#        iter = iter + 1
+#        if iter > maxIter:
+#            break
+#    if finished:
+#        self.ps.finishSolveStepByStep()
+#        return self.ps.numberPaths() - 1
+#
+#

--- a/tests/rrt.py
+++ b/tests/rrt.py
@@ -1,98 +1,99 @@
-from motion_planner import MotionPlanner
 from pyhpp.gepetto import Viewer
 import numpy as np
 from pinocchio import SE3
-from pyhpp.pinocchio import Device, urdf
-from pyhpp.core import Problem
+from pyhpp.pinocchio import Device
+from pyhpp.core import Problem, Roadmap, WeighedDistance, path
 
+# Robot configuration
 urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur5_joint_limited_robot.urdf"
 srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur5_joint_limited_robot.srdf"
 
+# Initialize robot and viewer
 robot = Device.create("ur5")
-
 viewer = Viewer("construction_set", robot)
 
+# Add robot and obstacles to scene
 viewer.addURDFToScene(0, "r0", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+viewer.addURDFObstacleToScene("/home/psardin/devel/nix-hpp/src/hpp-practicals/urdf/ur_benchmark/table.urdf", "table")
+viewer.addURDFObstacleToScene("/home/psardin/devel/nix-hpp/src/hpp-practicals/urdf/ur_benchmark/wall.urdf", "wall")
+viewer.addURDFObstacleToScene("/home/psardin/devel/nix-hpp/src/hpp-practicals/urdf/ur_benchmark/obstacles.urdf", "obstacles")
 
-viewer.addURDFObstacleToScene("package://hpp_practicals/urdf/ur_benchmark/obstacles.urdf", "obstacles")
-viewer.addURDFObstacleToScene("package://hpp_practicals/urdf/ur_benchmark/table.urdf", "table")
-viewer.addURDFObstacleToScene("package://hpp_practicals/urdf/ur_benchmark/wall.urdf", "wall")
+# Define initial and goal configurations
+qInit = np.array([0.2, -1.57, -1.8, 0, 0.8, 0])
+qGoal = np.array([1.57, -1.57, -1.8, 0, 0.8, 0])
+viewer.applyConfiguration(qInit)
 
-q2 = np.array([0.2, -1.57, -1.8, 0, 0.8, 0])
+# Setup problem and RRT components
+problem = Problem.create(robot)
+configurationShooter = problem.configurationShooter()
+steer = problem.steeringMethod()
+weighedDistance = WeighedDistance.create(robot)
+distance = weighedDistance.asDistancePtr_t()
 
-viewer.applyConfiguration(q2)
+# Initialize roadmap
+roadmap = Roadmap.create(distance, robot)
+roadmap.initNode(qInit)
+roadmap.addGoalNode(qGoal)
 
+# RRT algorithm parameters
+finished = False
+iter = 0
+maxIter = 1000
 
-# vf.loadObstacleModel(
-#     "package://hpp_practicals/urdf/ur_benchmark/obstacles.urdf", "obstacles"
-# )
-# vf.loadObstacleModel("package://hpp_practicals/urdf/ur_benchmark/table.urdf", "table")
-# vf.loadObstacleModel("package://hpp_practicals/urdf/ur_benchmark/wall.urdf", "wall")
+# Main RRT loop
+while not finished and iter < maxIter:
+    # Extend phase
+    newNodes = []
+    newEdges = []
+    q_rand = configurationShooter.shoot()
+    iter += 1
+    
+    # Try to extend from each connected component
+    for i in range(roadmap.numberConnectedComponents()):
+        cc = roadmap.getConnectedComponent(i)
+        q_near, d = roadmap.nearestNode(q_rand, cc)
+        directpath = steer(q_near, q_rand)
+        res, validPart, report = problem.pathValidation().validate(directpath, False)
+        
+        if res:
+            q_new = q_rand
+        else:
+            q_new = validPart.end()
+            
+        newNodes.append(q_new)
+        newEdges.append((q_near, q_new, validPart))
+    
+    # Add new nodes to roadmap
+    for q in newNodes:
+        roadmap.addNode(q)
+    
+    # Add new edges to roadmap
+    for q1, q2, path in newEdges:
+        roadmap.addEdge(q1, q2, path)
+    
+    # Connect phase
+    for q_new in newNodes:
+        for i in range(roadmap.numberConnectedComponents()):
+            cc = roadmap.getConnectedComponent(i)
+            q_near, d = roadmap.nearestNode(q_new, cc)
+            
+            if (q_near != q_new).all():
+                directpath = steer(q_new, q_near)
+                res, validPart, report = problem.pathValidation().validate(directpath, False)
+                
+                if res:
+                    roadmap.addEdge(q_new, q_near, validPart)
+                    break
+    
+    # Check if problem is solved
+    nbCC = roadmap.numberConnectedComponents()
+    if nbCC == 1:
+        print('Problem solved!')
+        finished = True
 
-# q1 = [0, -1.57, 1.57, 0, 0, 0]
-# q2 = [0.2, -1.57, -1.8, 0, 0.8, 0]
-# q3 = [1.57, -1.57, -1.8, 0, 0.8, 0]
-
-# ps.setInitialConfig(q2)
-# ps.addGoalConfig(q3)
-
-
-# m = MotionPlanner(robot, ps)
-# pathId = m.solveBiRRT(maxIter=1000)
-
-#############RRT############
-#def solveBiRRT(self, maxIter=float("inf")):
-#    #cpp#
-#    initProblem();
-#    pathPlanner_->startSolve();
-#    pathPlanner_->tryConnectInitAndGoals();
-#    roadmap_->pathExists();
-#    #cpp#
-#    finished = False
-#    iter = 0
-#    ps = self.ps
-#    while True:
-#        # RRT begin
-#        # Extend
-#        newNodes = list()
-#        newEdges = list()
-#        q_rand = robot.shootRandomConfig()
-#        for i in range(ps.numberConnectedComponents()):
-#            q_near, d = ps.getNearestConfig(q_rand,i)
-#            res, pid, msg = ps.directPath(q_near, q_rand, True)
-#            if res:
-#                q_new = q_rand
-#            else:
-#                q_new = ps.configAtParam(pid, ps.pathLength(pid))
-#            newNodes.append(q_new)
-#            newEdges.append((q_near, q_new, pid))
-#        for q in newNodes:
-#            ps.addConfigToRoadmap(q)
-#        for q1, q2, pid in newEdges:
-#            ps.addEdgeToRoadmap(q1, q2, pid, True)
-#        # connect
-#        for q_new in newNodes:
-#            for i in range(ps.numberConnectedComponents()):
-#                q_near, d = ps.getNearestConfig(q_new, i)
-#                # if q_near == q_new, q_new is in this connected component
-#                if q_near != q_new:
-#                    res, pid, msg = ps.directPath(q_new, q_near, True)
-#                    if res:
-#                        ps.addEdgeToRoadmap(q_new, q_near, pid, True)
-#                        print('finished')
-#                        break
-#        # RRT end
-#        # Check if the problem is solved.
-#        nbCC = self.ps.numberConnectedComponents()
-#        if nbCC == 1:
-#            # Problem solved
-#            finished = True
-#            break
-#        iter = iter + 1
-#        if iter > maxIter:
-#            break
-#    if finished:
-#        self.ps.finishSolveStepByStep()
-#        return self.ps.numberPaths() - 1
-#
-#
+# Compute and display final path
+if finished:
+    path = problem.target().computePath(roadmap)
+    viewer.displayPath(path)
+else:
+    print(f"Maximum iterations ({maxIter}) reached without finding solution")

--- a/tests/rrt.py
+++ b/tests/rrt.py
@@ -1,0 +1,32 @@
+from motion_planner import MotionPlanner
+from pyhpp.gepetto import Viewer
+import numpy as np
+from pinocchio import SE3
+from pyhpp.pinocchio import Device, urdf
+
+urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur5_joint_limited_robot.urdf"
+srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur5_joint_limited_robot.srdf"
+
+robot = Device.create("ur5")
+
+viewer = Viewer("construction_set", robot)
+
+viewer.addURDFToScene(0, "r0", "anchor", urdfFilename, srdfFilename, SE3.Identity())
+
+
+# vf.loadObstacleModel(
+#     "package://hpp_practicals/urdf/ur_benchmark/obstacles.urdf", "obstacles"
+# )
+# vf.loadObstacleModel("package://hpp_practicals/urdf/ur_benchmark/table.urdf", "table")
+# vf.loadObstacleModel("package://hpp_practicals/urdf/ur_benchmark/wall.urdf", "wall")
+
+# q1 = [0, -1.57, 1.57, 0, 0, 0]
+# q2 = [0.2, -1.57, -1.8, 0, 0.8, 0]
+# q3 = [1.57, -1.57, -1.8, 0, 0.8, 0]
+
+# ps.setInitialConfig(q2)
+# ps.addGoalConfig(q3)
+
+
+# m = MotionPlanner(robot, ps)
+# pathId = m.solveBiRRT(maxIter=1000)


### PR DESCRIPTION
Add a first draft of bindings to be able to use the roadmap in a manipulation problem. Example rrt.py shows how to use bindings in a path finding situation.